### PR TITLE
Fixes

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,7 @@ import { CoordinatesService } from './coordinates.service';
 import { GeocodeService } from './geocode.service';
 import { PlacesService } from './places.service';
 import { RegionsService } from './regions.service';
+import { MenuService } from './menu.service';
 
 import { AdminRegionComponent } from './admin-region/admin-region.component';
 import { AppComponent } from './app.component';
@@ -107,7 +108,8 @@ import { GeocodeInputComponent } from './geocode-input/geocode-input.component';
     GeocodeService,
     PlacesService,
     RegionsService,
-    MediaMatcher
+    MediaMatcher,
+    MenuService
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/coordinates.service.spec.ts
+++ b/src/app/coordinates.service.spec.ts
@@ -36,7 +36,7 @@ describe('CoordinatesService', () => {
     latitude: 35,
     longitude: -105,
     method: 'point',
-    place: '',
+    name: '',
     zoom: 16
   };
 

--- a/src/app/coordinates.service.ts
+++ b/src/app/coordinates.service.ts
@@ -248,7 +248,7 @@ export class CoordinatesService {
       longitude: this.roundLocation(longitude, confidence),
       zoom: location.zoom,
       method: location.method,
-      place: location.name
+      name: location.name
     });
 
     this.placesService.getPlaces(latitude, longitude);

--- a/src/app/coordinates.ts
+++ b/src/app/coordinates.ts
@@ -3,6 +3,6 @@ export interface Coordinates {
   latitude: number;
   longitude: number;
   method: string; // geocode, geolocate, pin, lat/lng
-  place: string; // geolocate
+  name: string; // geolocate
   zoom: number; // based on confidence
 }

--- a/src/app/geocode-input/geocode-input.component.spec.ts
+++ b/src/app/geocode-input/geocode-input.component.spec.ts
@@ -26,7 +26,7 @@ describe('GeocodeInputComponent', () => {
     latitude: 39.756650000000036,
     longitude: -105.22494999999998,
     method: 'geocode',
-    place: 'Golden, Colorado',
+    name: 'Golden, Colorado',
     zoom: 9
   };
 

--- a/src/app/geocode-input/geocode-input.component.ts
+++ b/src/app/geocode-input/geocode-input.component.ts
@@ -62,7 +62,7 @@ export class GeocodeInputComponent implements OnInit, OnDestroy {
       longitude: +location.feature.geometry.x,
       method: 'geocode',
       zoom: zoom,
-      place: location.name
+      name: location.name
     });
 
     // close dialog and stop progress spinner

--- a/src/app/geoserve/geoserve.component.css
+++ b/src/app/geoserve/geoserve.component.css
@@ -1,0 +1,5 @@
+.icon-button {
+  margin: 0 0.5em;
+  min-width: 0;
+  padding: 0 0.5em;
+}

--- a/src/app/geoserve/geoserve.component.html
+++ b/src/app/geoserve/geoserve.component.html
@@ -1,10 +1,21 @@
 <app-location-map></app-location-map>
 
-<app-location-output></app-location-output>
-<app-admin-region></app-admin-region>
-<app-authoritative-region></app-authoritative-region>
-<app-nearby-places></app-nearby-places>
-<app-neic-catalog-region></app-neic-catalog-region>
-<app-neic-response-region></app-neic-response-region>
-<app-offshore-region></app-offshore-region>
-<app-tectonic-summary-region></app-tectonic-summary-region>
+<div *ngIf="coordinatesService.coordinates | async; else noCoordinates">
+  <app-location-output></app-location-output>
+  <app-admin-region></app-admin-region>
+  <app-authoritative-region></app-authoritative-region>
+  <app-nearby-places></app-nearby-places>
+  <app-neic-catalog-region></app-neic-catalog-region>
+  <app-neic-response-region></app-neic-response-region>
+  <app-offshore-region></app-offshore-region>
+  <app-tectonic-summary-region></app-tectonic-summary-region>
+</div>
+
+<ng-template #noCoordinates>
+  <p class="alert info">
+    To select a location, click the
+    <button mat-raised-button class="icon-button" (click)="onClick()">
+      <i class="material-icons">location_searching</i>
+    </button>on the map.
+  </p>
+</ng-template>

--- a/src/app/geoserve/geoserve.component.spec.ts
+++ b/src/app/geoserve/geoserve.component.spec.ts
@@ -1,14 +1,30 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockComponent } from 'ng2-mock-component';
+import { MatDialog} from '@angular/material';
 
 import { GeoserveComponent } from './geoserve.component';
+
+import { CoordinatesService } from '../coordinates.service';
 
 
 describe('GeoserveComponent', () => {
   let component: GeoserveComponent;
   let fixture: ComponentFixture<GeoserveComponent>;
+  let coordinatesService;
 
   beforeEach(async(() => {
+    const coordinatesServiceStub = {
+      setCoordinates: (location: any) => {
+        console.log('stubbified!');
+      }
+    };
+
+    const dialogStub = {
+      open: () => {
+        console.log('stubbified!');
+      }
+    };
+
     TestBed.configureTestingModule({
       declarations: [
         GeoserveComponent,
@@ -23,7 +39,11 @@ describe('GeoserveComponent', () => {
         MockComponent({selector: 'app-neic-response-region'}),
         MockComponent({selector: 'app-offshore-region'}),
         MockComponent({selector: 'app-tectonic-summary-region'})
-      ]
+      ],
+      providers: [
+        {provide: CoordinatesService, useValue: coordinatesServiceStub},
+        {provide: MatDialog, useValue: dialogStub}
+      ],
     })
     .compileComponents();
   }));
@@ -32,6 +52,9 @@ describe('GeoserveComponent', () => {
     fixture = TestBed.createComponent(GeoserveComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+
+    // stub coordinates.service
+    coordinatesService = fixture.debugElement.injector.get(CoordinatesService);
   });
 
   it('should create', () => {

--- a/src/app/geoserve/geoserve.component.ts
+++ b/src/app/geoserve/geoserve.component.ts
@@ -1,5 +1,10 @@
 import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material';
 
+import * as L from 'leaflet';
+
+import { CoordinatesService } from '../coordinates.service';
+import { LocationDialogComponent } from '../location-dialog/location-dialog.component';
 
 @Component({
   selector: 'app-geoserve',
@@ -7,9 +12,19 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./geoserve.component.css']
 })
 export class GeoserveComponent implements OnInit {
+  public control;
 
-  constructor () { }
+  constructor (
+    private coordinatesService: CoordinatesService,
+    public dialog: MatDialog
+  ) { }
 
   ngOnInit() {
+  }
+
+  onClick(): void {
+    if (this.dialog && LocationDialogComponent) {
+      this.dialog.open(LocationDialogComponent);
+    }
   }
 }

--- a/src/app/hazdev-template/hazdev-template.component.html
+++ b/src/app/hazdev-template/hazdev-template.component.html
@@ -24,6 +24,7 @@
       class="site-footer"
       [mode]="mobileQuery.matches ? 'over' : 'side'"
       [opened]="!mobileQuery.matches"
+      (openedChange)="onSideNavChange($event)"
   >
     <app-hazdev-template-navigation
         [NAVIGATION]="NAVIGATION"

--- a/src/app/hazdev-template/hazdev-template.component.spec.ts
+++ b/src/app/hazdev-template/hazdev-template.component.spec.ts
@@ -5,6 +5,8 @@ import { MediaMatcher } from '@angular/cdk/layout';
 
 import { HazdevTemplateComponent } from './hazdev-template.component';
 
+import { MenuService } from '../menu.service';
+
 describe('HazdevTemplateComponent', () => {
   let component: HazdevTemplateComponent;
   let fixture: ComponentFixture<HazdevTemplateComponent>;
@@ -35,7 +37,8 @@ describe('HazdevTemplateComponent', () => {
         NO_ERRORS_SCHEMA
       ],
       providers: [
-        {provide: MediaMatcher, useValue: mediaMatcherStub}
+        {provide: MediaMatcher, useValue: mediaMatcherStub},
+        MenuService
       ]
     })
     .compileComponents();

--- a/src/app/hazdev-template/hazdev-template.component.ts
+++ b/src/app/hazdev-template/hazdev-template.component.ts
@@ -1,5 +1,7 @@
 import { ChangeDetectorRef, Component, OnInit, OnDestroy, Input } from '@angular/core';
-import {MediaMatcher} from '@angular/cdk/layout';
+import { MediaMatcher } from '@angular/cdk/layout';
+
+import { MenuService } from '../menu.service';
 
 @Component({
   selector: 'app-hazdev-template',
@@ -9,7 +11,6 @@ import {MediaMatcher} from '@angular/cdk/layout';
 export class HazdevTemplateComponent implements OnInit, OnDestroy {
   mobileQuery: MediaQueryList;
   private _mobileQueryListener: () => void;
-
   public href = '';
 
   @Input() TITLE: string;
@@ -41,7 +42,11 @@ export class HazdevTemplateComponent implements OnInit, OnDestroy {
   @Input() SITE_SITENAV: any[];
   @Input() SITE_URL = 'http://localhost.localdomain';
 
-  constructor (changeDetectorRef: ChangeDetectorRef, media: MediaMatcher) {
+  constructor (
+    changeDetectorRef: ChangeDetectorRef,
+    media: MediaMatcher,
+    public menuService: MenuService
+  ) {
     this.mobileQuery = media.matchMedia('(max-width: 768px)');
     this._mobileQueryListener = () => changeDetectorRef.detectChanges();
     this.mobileQuery.addListener(this._mobileQueryListener);
@@ -56,5 +61,10 @@ export class HazdevTemplateComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+  }
+
+  onSideNavChange(event: any): void {
+    // pass true or false indicating the state of the menu
+    this.menuService.setState(event);
   }
 }

--- a/src/app/location-map/location-map.component.spec.ts
+++ b/src/app/location-map/location-map.component.spec.ts
@@ -7,11 +7,13 @@ import { LocationMapComponent } from './location-map.component';
 
 import { Coordinates } from '../coordinates';
 import { CoordinatesService } from '../coordinates.service';
+import { MenuService } from '../menu.service';
 
 describe('LocationMapComponent', () => {
   let component: LocationMapComponent;
   let fixture: ComponentFixture<LocationMapComponent>;
   let coordinatesService;
+  let menuService;
 
   const coordinates: Coordinates = {
     confidence: 1,
@@ -43,6 +45,14 @@ describe('LocationMapComponent', () => {
       }
     };
 
+    const menuServiceStub = {
+      open: {
+        subscribe: () => {
+          console.log('stubbified!');
+        }
+      }
+    };
+
     TestBed.configureTestingModule({
       declarations: [
         LocationMapComponent
@@ -50,6 +60,7 @@ describe('LocationMapComponent', () => {
       providers: [
         {provide: CoordinatesService, useValue: coordinatesServiceStub},
         {provide: MatDialog, useValue: dialogStub},
+        {provide: MenuService, useValue: menuServiceStub}
       ]
     })
     .compileComponents();
@@ -60,6 +71,7 @@ describe('LocationMapComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
     coordinatesService = fixture.debugElement.injector.get(CoordinatesService);
+    menuService = fixture.debugElement.injector.get(MenuService);
   });
 
   it('should create', () => {
@@ -101,7 +113,6 @@ describe('LocationMapComponent', () => {
       expect(component.map).not.toBeNull();
     });
   });
-
 
   describe('createMarker', () => {
     it('should create a marker', () => {
@@ -202,5 +213,23 @@ describe('LocationMapComponent', () => {
     });
   });
 
+  describe('subscribeToServices', () => {
+    it('should subscribe to the coordinates service', () => {
+      let coordinatesServiceSpy;
+
+      coordinatesServiceSpy = spyOn(coordinatesService.coordinates, 'subscribe');
+      component.subscribeToServices();
+
+      expect(coordinatesServiceSpy).toHaveBeenCalled();
+    });
+    it('should subscribe to the menu service', () => {
+      let menuServiceSpy;
+
+      menuServiceSpy = spyOn(menuService.open, 'subscribe');
+      component.subscribeToServices();
+
+      expect(menuServiceSpy).toHaveBeenCalled();
+    });
+  });
 
 });

--- a/src/app/location-map/location-map.component.spec.ts
+++ b/src/app/location-map/location-map.component.spec.ts
@@ -18,7 +18,7 @@ describe('LocationMapComponent', () => {
     latitude: 35,
     longitude: -105,
     method: 'point',
-    place: '',
+    name: '',
     zoom: 16
   };
 

--- a/src/app/location-output/location-output.component.html
+++ b/src/app/location-output/location-output.component.html
@@ -1,9 +1,9 @@
 <div *ngIf="coordinatesService.coordinates | async; let coordinates" class="location-output">
   <h2>Location</h2>
-  <span class="coordinates">
+  <p class="coordinates alert success">
     (
       {{ coordinates?.latitude }},
       {{ coordinates?.longitude }}
     )
-  </span>
+  </p>
 </div>

--- a/src/app/menu.service.spec.ts
+++ b/src/app/menu.service.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed, getTestBed, inject } from '@angular/core/testing';
+
+import { MenuService } from './menu.service';
+
+describe('MenuService', () => {
+  let injector: TestBed,
+      menuService: MenuService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [MenuService]
+    });
+    injector = getTestBed();
+    menuService = injector.get(MenuService);
+  });
+
+  it('should be created', inject([MenuService], (service: MenuService) => {
+    expect(service).toBeTruthy();
+  }));
+
+
+  describe('empty', () => {
+
+    it('notifies with null', () => {
+      const state = true;
+      const spy = jasmine.createSpy('subscriber spy');
+      const open = menuService.open;
+
+      open.subscribe(spy);
+      menuService.setState(state);
+
+      expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(state);
+    });
+  });
+
+});

--- a/src/app/menu.service.ts
+++ b/src/app/menu.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs/Observable';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+
+@Injectable()
+export class MenuService {
+
+  private _open = new BehaviorSubject<boolean>(null);
+  public readonly open = this._open.asObservable();
+
+  constructor() { }
+
+  setState (state: boolean): void {
+    this._open.next(state);
+  }
+}

--- a/src/app/places.service.spec.ts
+++ b/src/app/places.service.spec.ts
@@ -47,6 +47,9 @@ describe('PlacesService', () => {
 
   describe('getPlaces', () => {
     it('calls http get', () => {
+      let latitude,
+          longitude;
+
       const placesJson = {
         event: {
           features: [
@@ -56,10 +59,12 @@ describe('PlacesService', () => {
         }
       };
 
-      placesService.getPlaces('latitude', 'longitude');
+      latitude = 0;
+      longitude = 0;
+      placesService.getPlaces(latitude, longitude);
 
       const request = httpClient.expectOne(placesService.API_URL +
-        '?latitude=latitude&longitude=longitude&type=event');
+        `?latitude=${latitude}&longitude=${longitude}&type=event`);
 
       expect(request.request.method).toBe('GET');
       request.flush(placesJson);
@@ -70,16 +75,55 @@ describe('PlacesService', () => {
     });
 
     it('handles errors', () => {
-      placesService.getPlaces('latitude', 'longitude');
+      let latitude,
+          longitude;
+
+      latitude = 0;
+      longitude = 0;
+      placesService.getPlaces(latitude, longitude);
 
       const request = httpClient.expectOne(placesService.API_URL +
-        '?latitude=latitude&longitude=longitude&type=event');
+        `?latitude=${latitude}&longitude=${longitude}&type=event`);
 
       request.error(new ErrorEvent('You may safely ignore this error.'));
 
       placesService.places.subscribe((result) => {
         expect(result.length).toBe(0);
       });
+    });
+  });
+
+
+  describe('buildUrl', () => {
+    it('returns a url', () => {
+      let url;
+
+      const lat = 0;
+      const lng = 0;
+
+      url = placesService.buildUrl(lat, lng);
+
+      expect(url.indexOf(`latitude=${lat}`)).not.toEqual(-1);
+      expect(url.indexOf(`longitude=${lng}`)).not.toEqual(-1);
+    });
+    it('normalizes longitude in the url', () => {
+      let lng,
+          url;
+
+      const lat = 0;
+      lng = 720;
+
+      url = placesService.buildUrl(lat, lng);
+
+      expect(url.indexOf(`latitude=${lat}`)).not.toEqual(-1);
+      expect(url.indexOf(`longitude=0`)).not.toEqual(-1);
+
+      lng = -720;
+
+      url = placesService.buildUrl(lat, lng);
+
+      expect(url.indexOf(`latitude=${lat}`)).not.toEqual(-1);
+      expect(url.indexOf(`longitude=0`)).not.toEqual(-1);
     });
   });
 });

--- a/src/app/places.service.ts
+++ b/src/app/places.service.ts
@@ -23,7 +23,7 @@ export class PlacesService {
     this._places.next(null);
   }
 
-  getPlaces (latitude: string, longitude: string): void {
+  getPlaces (latitude: number, longitude: number): void {
     const url = this.buildUrl(latitude, longitude);
 
     this.http.get<any>(url).pipe(
@@ -41,7 +41,15 @@ export class PlacesService {
     };
   }
 
-  private buildUrl (latitude: string, longitude: string): string {
+  buildUrl (latitude: number, longitude: number): string {
+    // normalize longitude for search
+    while (longitude <= -180) {
+      longitude += 360;
+    }
+    while (longitude > 180) {
+      longitude -= 360;
+    }
+
     return this.API_URL + '?' +
       `latitude=${latitude}` +
       `&longitude=${longitude}` +

--- a/src/app/regions.service.spec.ts
+++ b/src/app/regions.service.spec.ts
@@ -46,6 +46,9 @@ describe('RegionsService', () => {
 
   describe('getRegions', () => {
     it('calls http get', () => {
+      let latitude,
+          longitude;
+
       const regionsJson = {
         admin: {
           features: [
@@ -54,10 +57,12 @@ describe('RegionsService', () => {
         }
       };
 
-      regionsService.getRegions('latitude', 'longitude');
+      latitude = 0;
+      longitude = 0;
+      regionsService.getRegions(latitude, longitude);
 
       const request = httpClient.expectOne(regionsService.API_URL +
-        '?latitude=latitude&longitude=longitude');
+        `?latitude=${latitude}&longitude=${longitude}`);
 
       expect(request.request.method).toBe('GET');
       request.flush(regionsJson);
@@ -68,16 +73,54 @@ describe('RegionsService', () => {
     });
 
     it('handles errors', () => {
-      regionsService.getRegions('latitude', 'longitude');
+      let latitude,
+          longitude;
+
+      latitude = 0;
+      longitude = 0;
+      regionsService.getRegions(latitude, longitude);
 
       const request = httpClient.expectOne(regionsService.API_URL +
-        '?latitude=latitude&longitude=longitude');
+        `?latitude=${latitude}&longitude=${longitude}`);
 
       request.error(new ErrorEvent('You may safely ignore this error.'));
 
       regionsService.adminRegions.subscribe((result) => {
         expect(result).toBe(null);
       });
+    });
+  });
+
+  describe('buildUrl', () => {
+    it('returns a url', () => {
+      let url;
+
+      const lat = 0;
+      const lng = 0;
+
+      url = regionsService.buildUrl(lat, lng);
+
+      expect(url.indexOf(`latitude=${lat}`)).not.toEqual(-1);
+      expect(url.indexOf(`longitude=${lng}`)).not.toEqual(-1);
+    });
+    it('normalizes longitude in the url', () => {
+      let lng,
+          url;
+
+      const lat = 0;
+      lng = 720;
+
+      url = regionsService.buildUrl(lat, lng);
+
+      expect(url.indexOf(`latitude=${lat}`)).not.toEqual(-1);
+      expect(url.indexOf(`longitude=0`)).not.toEqual(-1);
+
+      lng = -720;
+
+      url = regionsService.buildUrl(lat, lng);
+
+      expect(url.indexOf(`latitude=${lat}`)).not.toEqual(-1);
+      expect(url.indexOf(`longitude=0`)).not.toEqual(-1);
     });
   });
 });

--- a/src/app/regions.service.ts
+++ b/src/app/regions.service.ts
@@ -49,7 +49,7 @@ export class RegionsService {
     this._tectonic.next(null);
   }
 
-  getRegions (latitude: string, longitude: string): void {
+  getRegions (latitude: number, longitude: number): void {
     const url = this.buildUrl(latitude, longitude);
 
     this.http.get<any>(url).pipe(
@@ -95,7 +95,15 @@ export class RegionsService {
     };
   }
 
-  private buildUrl (latitude: string, longitude: string): string {
+  buildUrl (latitude: number, longitude: number): string {
+    // normalize longitude for search
+    while (longitude <= -180) {
+      longitude += 360;
+    }
+    while (longitude > 180) {
+      longitude -= 360;
+    }
+
     return this.API_URL + '?' +
       `latitude=${latitude}` +
       `&longitude=${longitude}`;

--- a/src/styles.css
+++ b/src/styles.css
@@ -170,3 +170,74 @@ mark {
   .four-of-five  { width: calc(100%*4/5); }
 
 }
+
+
+.alert {
+  background-color: #ccc;
+  margin: 1em 0;
+  overflow: hidden;
+  padding: calc(1em * 3/2) calc(1em * 2);
+  position: relative;
+}
+
+.alert > :first-child {
+  margin-top: 0;
+}
+
+.alert > :last-child {
+  margin-bottom: 0;
+}
+
+.error:before,
+.info:before,
+.success:before,
+.warning:before {
+  content: '';
+  font-family: 'Material Icons';
+  font-size: 4.5em;
+  left: -0.2em;
+  line-height: 1;
+  opacity: 0.075;
+  position: absolute;
+  top: -0.2em;
+}
+
+.error {
+  background-color: #F9DEDE;
+}
+
+.error:before {
+  content: '\0e15c';
+}
+
+
+.info {
+  background-color: #E8F5FA;
+}
+
+.info:before {
+  content: '\0e88e';
+}
+
+
+.success {
+  background-color: #E5FCDE;
+}
+
+.success:before {
+  content: '\0e86c';
+}
+
+
+.warning {
+  background-color: #FDF7DC;
+}
+
+.warning:before {
+  content: '\0e002';
+}
+
+
+.no-icon:before {
+  content: '';
+}


### PR DESCRIPTION
- Consistently reference coordinate.name instead of "place"
- Add tests for buildUrl method, normalize lat/lng for place/regions searches. This fixes a bug where the map marker was always plotted between -180 <-> 180 (event when dragged outside normal world bounds
- Update map to invalidate the size when the menu is toggled. This fixes a bug where not all tiles are loaded when the side navigation is collapsed.
- Add helper message to explain location control on the map