### PR TITLE
Issue 51

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -44,6 +44,7 @@ import { TectonicSummaryRegionComponent } from './tectonic-summary-region/tecton
 import { LocationDialogComponent } from './location-dialog/location-dialog.component';
 import { GeolocateInputComponent } from './geolocate-input/geolocate-input.component';
 import { GeocodeInputComponent } from './geocode-input/geocode-input.component';
+import { OverlaysService } from './overlays.service';
 
 
 
@@ -109,7 +110,8 @@ import { GeocodeInputComponent } from './geocode-input/geocode-input.component';
     PlacesService,
     RegionsService,
     MediaMatcher,
-    MenuService
+    MenuService,
+    OverlaysService
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/location-map/location-map.component.spec.ts
+++ b/src/app/location-map/location-map.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientModule } from '@angular/common/http';
 import { MatDialog } from '@angular/material';
 
 import * as L from 'leaflet';
@@ -8,6 +9,8 @@ import { LocationMapComponent } from './location-map.component';
 import { Coordinates } from '../coordinates';
 import { CoordinatesService } from '../coordinates.service';
 import { MenuService } from '../menu.service';
+import { OverlaysService } from '../overlays.service';
+
 
 describe('LocationMapComponent', () => {
   let component: LocationMapComponent;
@@ -53,17 +56,32 @@ describe('LocationMapComponent', () => {
       }
     };
 
+    const overlaysServiceStub = {
+      getOverlays: () => {
+        console.log('stubbified!');
+      },
+      overlays: {
+        subscribe: () => {
+          console.log('stubbified!');
+        }
+      }
+    };
+
     TestBed.configureTestingModule({
       declarations: [
         LocationMapComponent
       ],
+      imports: [
+        HttpClientModule,
+      ],
       providers: [
         {provide: CoordinatesService, useValue: coordinatesServiceStub},
         {provide: MatDialog, useValue: dialogStub},
-        {provide: MenuService, useValue: menuServiceStub}
+        {provide: MenuService, useValue: menuServiceStub},
+        {provide: OverlaysService, useValue: overlaysServiceStub}
       ]
-    })
-    .compileComponents();
+    }).compileComponents();
+
   }));
 
   beforeEach(() => {

--- a/src/app/location-map/location-map.component.ts
+++ b/src/app/location-map/location-map.component.ts
@@ -71,8 +71,10 @@ export class LocationMapComponent implements OnDestroy, OnInit {
 
     this.overlaysService.overlays.subscribe((layers) => {
       // add overlays
-      for (let name in layers) {
-        this.layerControl.addOverlay(layers[name], name);
+      for (const name in layers) {
+        if (layers.hasOwnProperty(name)) {
+          this.layerControl.addOverlay(layers[name], name);
+        }
       }
     });
   }

--- a/src/app/location-map/location-map.component.ts
+++ b/src/app/location-map/location-map.component.ts
@@ -5,6 +5,7 @@ import * as L from 'leaflet';
 
 import { CoordinatesService } from '../coordinates.service';
 import { MenuService } from '../menu.service';
+import { OverlaysService } from '../overlays.service';
 
 import { Coordinates } from '../coordinates';
 import { LocationDialogComponent } from '../location-dialog/location-dialog.component';
@@ -16,15 +17,21 @@ import { LocationDialogComponent } from '../location-dialog/location-dialog.comp
   encapsulation: ViewEncapsulation.None
 })
 export class LocationMapComponent implements OnDestroy, OnInit {
+  baseLayers: L.LayerGroup;
+  layerControl: L.Control.Layers;
   map: L.Map;
   marker: L.Marker;
+  overlays: L.LayerGroup;
+
   coordinatesObservable;
   menuObservable;
+
 
   constructor(
     private coordinatesService: CoordinatesService,
     public dialog: MatDialog,
-    private menuService: MenuService
+    private menuService: MenuService,
+    private overlaysService: OverlaysService
   ) {}
 
   ngOnDestroy() {
@@ -45,11 +52,33 @@ export class LocationMapComponent implements OnDestroy, OnInit {
     // Add baselayers to map
     this.addBaselayers();
 
+    // Get region overlays
+    this.getOverlays();
+
     // Add location control to map
     this.addLocationControl();
 
     // subscribe to location changes and menu toggling
     this.subscribeToServices();
+
+    // subscribe to location changes
+    this.coordinatesService.coordinates.subscribe((coordinates) => {
+      if (coordinates) {
+        this.moveMarker(coordinates);
+        this.moveMap(coordinates);
+      }
+    });
+
+    this.overlaysService.overlays.subscribe((layers) => {
+      // add overlays
+      for (let name in layers) {
+        this.layerControl.addOverlay(layers[name], name);
+      }
+    });
+  }
+
+  getOverlays (): void {
+     this.overlaysService.getOverlays();
   }
 
   /**
@@ -97,8 +126,8 @@ export class LocationMapComponent implements OnDestroy, OnInit {
       'Terrain': terrain
     };
 
-    // Add layers to map
-    L.control.layers(baseMaps).addTo(this.map);
+    // Add layer control to map
+    this.layerControl = L.control.layers(baseMaps).addTo(this.map);
   }
 
   /**

--- a/src/app/overlays.service.spec.ts
+++ b/src/app/overlays.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { OverlaysService } from './overlays.service';
+
+describe('OverlaysService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [OverlaysService]
+    });
+  });
+
+  it('should be created', inject([OverlaysService], (service: OverlaysService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/overlays.service.spec.ts
+++ b/src/app/overlays.service.spec.ts
@@ -1,12 +1,25 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { TestBed, getTestBed, inject } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { OverlaysService } from './overlays.service';
 
 describe('OverlaysService', () => {
+  let httpClient: HttpTestingController,
+      injector: TestBed;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule
+      ],
       providers: [OverlaysService]
     });
+    injector = getTestBed();
+    httpClient = injector.get(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpClient.verify();
   });
 
   it('should be created', inject([OverlaysService], (service: OverlaysService) => {

--- a/src/app/overlays.service.ts
+++ b/src/app/overlays.service.ts
@@ -87,8 +87,8 @@ export class OverlaysService {
       '_type': overlay.name,
       '_url': this.LAYERS_URL,
       // set styles on the layer
-      options: {
-        style: {
+      'options': {
+        'style': {
           'color': color,
           'fillOpacity': 0.4,
           'opacity': 1,
@@ -98,6 +98,7 @@ export class OverlaysService {
       },
 
       onAdd: function (map) {
+        L.GeoJSON.prototype.onAdd.call(this, map);
         if (!this._loaded) {
           // fetch data once
           this._loaded = true;

--- a/src/app/overlays.service.ts
+++ b/src/app/overlays.service.ts
@@ -79,6 +79,7 @@ export class OverlaysService {
   buildRegionLayer(overlay: any): void {
     const color = this.COLORS[this.COLORS_INDEX++ % this.COLORS.length];
     const http = this.http;
+    const errorHandler = this.handleError;
 
     const RegionsLayer = L.GeoJSON.extend({
       // Not sure how to make angular call super class initialize,
@@ -112,9 +113,7 @@ export class OverlaysService {
         url = this._url + '?type=' + this._type;
 
         http.get(url).pipe(
-          catchError(() => {
-            return this.handleError('loadData', null);
-          })
+          catchError(errorHandler('loadData', null))
         ).subscribe((data) => {
           if (data === null) {
             // let user try again

--- a/src/app/overlays.service.ts
+++ b/src/app/overlays.service.ts
@@ -66,11 +66,9 @@ export class OverlaysService {
   }
 
   /**
-   * build an array of regions layers, 
+   * build an array of regions layers
    */
   buildRegionLayers(overlays: any[]): void {
-    let layer;
-
     overlays.forEach((overlay) => {
       this.regionOverlays[overlay.title] = this.buildRegionLayer(overlay);
     });
@@ -81,7 +79,7 @@ export class OverlaysService {
   buildRegionLayer(overlay: any): void {
     const http = this.http;
 
-    let RegionsLayer = L.GeoJSON.extend({
+    const RegionsLayer = L.GeoJSON.extend({
       // Not sure how to make angular call super class initialize,
       // so cheat and set defaults this way
       '_loaded': false,
@@ -113,7 +111,7 @@ export class OverlaysService {
             return this.handleError('loadData', null);
           })
         ).subscribe((data) => {
-          if data == null {
+          if (data === null) {
             // let user try again
             this._loaded = false;
             return;

--- a/src/app/overlays.service.ts
+++ b/src/app/overlays.service.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
+import { catchError, tap } from 'rxjs/operators';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+
+import * as L from 'leaflet';
+
+@Injectable()
+export class OverlaysService {
+  public readonly LAYERS_URL = 'https://earthquake.usgs.gov/ws/geoserve/layers.json';
+  private readonly COLORS = [
+    '#1f78b4', // teal
+    '#ffff99', // yellow
+    '#33a02c', // green
+    '#e31a1c', // red
+    '#ff7f00', // orange
+    '#6a3d9a', // purple
+    '#b15928' // brown
+  ];
+  private COLORS_INDEX = 0;
+  regionOverlays = {};
+
+  private _overlays: BehaviorSubject<any> = new BehaviorSubject<any>(null);
+  public readonly overlays: Observable<any> = this._overlays.asObservable();
+
+  constructor(private http: HttpClient) { }
+
+  empty (): void {
+    this._overlays.next(null);
+  }
+
+  /**
+   * Fetch overlays from geoserve ws
+   */
+  getOverlays(): void {
+    let overlays;
+
+    this.http.get<any>(this.LAYERS_URL).pipe(
+      catchError(this.handleError('getOverlays',
+        {
+          parameters: {
+            required: {
+              type: {
+                values: []
+              }
+            }
+          }
+        }
+      ))
+    ).subscribe((response) => {
+      overlays = response.parameters.required.type.values;
+      if (overlays && overlays.length !== 0) {
+        this.buildRegionLayers(overlays);
+      }
+    });
+  }
+
+  private handleError<T> (action: string, result?: T) {
+    return (error: any): Observable<T> => {
+      console.error(error);
+      return of(result as T);
+    };
+  }
+
+  /**
+   * build an array of regions layers, 
+   */
+  buildRegionLayers(overlays: any[]): void {
+    let layer;
+
+    overlays.forEach((overlay) => {
+      this.regionOverlays[overlay.title] = this.buildRegionLayer(overlay);
+    });
+
+    this._overlays.next(this.regionOverlays);
+  }
+
+  buildRegionLayer(overlay: any): void {
+    const http = this.http;
+
+    let RegionsLayer = L.GeoJSON.extend({
+      // Not sure how to make angular call super class initialize,
+      // so cheat and set defaults this way
+      '_loaded': false,
+      '_type': overlay.name,
+      '_url': this.LAYERS_URL,
+      'style': {
+            'color': this.COLORS[this.COLORS_INDEX++ % this.COLORS.length],
+            'fillOpacity': 0.4,
+            'opacity': 1,
+            'weight': 2,
+            'clickable': false
+      },
+
+      onAdd: function (map) {
+        if (!this._loaded) {
+          // fetch data once
+          this._loaded = true;
+          this._loadData();
+        }
+      },
+
+      _loadData: function () {
+        let url;
+
+        url = this._url + '?type=' + this._type;
+
+        http.get(url).pipe(
+          catchError(() => {
+            return this.handleError('loadData', null);
+          })
+        ).subscribe((data) => {
+          if data == null {
+            // let user try again
+            this._loaded = false;
+            return;
+          }
+          this.addData(data[this._type]);
+        });
+      }
+    });
+
+    return new RegionsLayer();
+  }
+
+}

--- a/src/app/overlays.service.ts
+++ b/src/app/overlays.service.ts
@@ -77,6 +77,7 @@ export class OverlaysService {
   }
 
   buildRegionLayer(overlay: any): void {
+    const color = this.COLORS[this.COLORS_INDEX++ % this.COLORS.length];
     const http = this.http;
 
     const RegionsLayer = L.GeoJSON.extend({
@@ -85,12 +86,15 @@ export class OverlaysService {
       '_loaded': false,
       '_type': overlay.name,
       '_url': this.LAYERS_URL,
-      'style': {
-            'color': this.COLORS[this.COLORS_INDEX++ % this.COLORS.length],
-            'fillOpacity': 0.4,
-            'opacity': 1,
-            'weight': 2,
-            'clickable': false
+      // set styles on the layer
+      options: {
+        style: {
+          'color': color,
+          'fillOpacity': 0.4,
+          'opacity': 1,
+          'weight': 2,
+          'clickable': false
+        }
       },
 
       onAdd: function (map) {


### PR DESCRIPTION
Fixes #51 

You may think some of this code looks weird, but `L.GeoJSON.prototype.initialize.call()` fails because angular thinks that the `initialize` method does not exist on `L.GeoJSON.prototype`