### PR TITLE
Wrap the earthquake-geoserve-ui in the hazdev-ng-template

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -22,6 +22,11 @@
                 "input": "node_modules/leaflet/dist/images",
                 "output": "/leaflet"
               },
+              {
+                "glob": "**/*",
+                "input": "node_modules/hazdev-ng-template/assets",
+                "output": "/assets"
+              },
               "src/assets",
               "src/favicon.ico"
             ],

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@angular/router": "6.1.8",
     "core-js": "^2.5.3",
     "hazdev-ng-location-view": "0.0.4",
+    "hazdev-ng-template": "^0.2.1",
     "leaflet": "^1.2.0",
     "rxjs": "^6.2.1",
     "zone.js": "^0.8.26"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,4 @@
-<h1>Geoserve</h1>
-<app-geoserve></app-geoserve>
+<hazdev-template>
+  <h1>Geoserve</h1>
+  <app-geoserve></app-geoserve>
+</hazdev-template>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { GeoserveOutputModule } from 'hazdev-ng-geoserve-output';
 import { LocationViewModule } from 'hazdev-ng-location-view';
+import { HazdevTemplateModule } from 'hazdev-ng-template';
 
 import { AppComponent } from './app.component';
 import { GeoserveComponent } from './geoserve/geoserve.component';
@@ -29,6 +30,7 @@ import { GeoserveComponent } from './geoserve/geoserve.component';
     BrowserAnimationsModule,
     FormsModule,
     GeoserveOutputModule.forRoot(),
+    HazdevTemplateModule,
     HttpClientModule,
     LocationViewModule.forRoot(),
     MatButtonModule,


### PR DESCRIPTION
I am not sure what side navigation links we want for this application. 

![screen shot 2018-10-03 at 6 28 45 pm](https://user-images.githubusercontent.com/1932750/46446575-4dacc900-c73a-11e8-97ca-6e0fbf82d99c.png)
